### PR TITLE
Fix for #27 and use Tinkers' Antique instead of old TiCo :)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ repositories {
     }
     maven {
         name 'CurseMaven'
-        url 'https://cursemaven.com'
+        url 'https://curse.cleanroommc.com'
         content {
             includeGroup 'curse.maven'
         }
@@ -108,11 +108,10 @@ dependencies {
     }
 
     // Example of deobfuscating a dependency
-    // implementation rfg.deobf('curse.maven:had-enough-items-557549:4543375')
-    implementation rfg.deobf('curse.maven:had-enough-items-557549:5229422')
+    implementation "mezz:jei:4.28.1"
     implementation rfg.deobf('curse.maven:hwyla-253449:2568751')
     implementation rfg.deobf('curse.maven:mantle-74924:2713386')
-    implementation rfg.deobf('curse.maven:tinkers-construct-74072:2902483')
+    implementation rfg.deobf('curse.maven:tinkers-antique-1242239:6752868')
     implementation rfg.deobf('curse.maven:constructs-armory-287683:3174535')
 
     if (project.use_mixins.toBoolean()) {

--- a/src/main/java/com/progwml6/natura/tools/item/tools/ItemNaturaFlintAndBlaze.java
+++ b/src/main/java/com/progwml6/natura/tools/item/tools/ItemNaturaFlintAndBlaze.java
@@ -6,6 +6,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemFlintAndSteel;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
@@ -16,7 +17,7 @@ import net.minecraft.world.World;
 
 import com.progwml6.natura.Natura;
 
-public class ItemNaturaFlintAndBlaze extends Item
+public class ItemNaturaFlintAndBlaze extends ItemFlintAndSteel
 {
     public ItemNaturaFlintAndBlaze()
     {


### PR DESCRIPTION
Simple PR containing two things:
- fix #27 Blaze and Flint now exends `ItemFlintAndSteel` instead of `Item` making it compatible with other mods like the additional Pyrotech integration added by `Ender's Modpack Tweaks`
- update dependencies, while switching to Tinkers' Antique as it's also one of your forks :)