### PR TITLE
Thornvine generation fix

### DIFF
--- a/src/main/java/com/progwml6/natura/world/worldgen/VineGenerator.java
+++ b/src/main/java/com/progwml6/natura/world/worldgen/VineGenerator.java
@@ -81,7 +81,7 @@ public class VineGenerator implements IWorldGenerator
 
     public boolean shouldGenerateInDimension(int dimension)
     {
-        for (int dimensionId : Config.overworldWorldGenWhitelist)
+        for (int dimensionId : Config.netherWorldGenWhitelist)
         {
             if (dimension == dimensionId)
             {


### PR DESCRIPTION
changes in this PR:
- when attempting to generate thornvines for the nether, use `netherWorldGenWhitelist` instead of `overworldWorldGenWhitelist`.

prior to https://github.com/Elite-Modding-Team/NaturaLegacy/commit/05b07509421fc0d700dbf0f5afc636145dff7696 the default configs mean that Natura would attempt to generate thornvines in the nether, but after switching to a whitelist the  default config prevents thornvine generation. 
it is unclear why this used the overworld config in the first place (which it has since the config was created), but it is clearly incorrect.